### PR TITLE
feat: add attributes to open links in new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 <!--Languages & Tools Section Body-->   
 <p align="center">
-  <a href="https://skillicons.dev">
+  <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer">
     <img src="https://skillicons.dev/icons?i=html,css,js,react,ts,tailwind,materialui,vite,webpack,babel,vitest,jest,nodejs,express,npm,yarn,git,figma,&perline=9" />
   </a>
 </p>
@@ -51,7 +51,7 @@
     <p align="center">
         <img src="https://static.wikia.nocookie.net/kpop/images/1/16/QWER_Manito_group_concept_photo_1.png/revision/latest/scale-to-width-down/1000?cb=20240327112956" alt="Higuchi Ai Image" width="200"/>
     </p>
-    <h2 align="center">Artist: <a href="https://www.higuchiai.com/">Higuchi Ai</a></h2>
+    <h2 align="center">Artist: <a href="https://www.higuchiai.com/" target="_blank" rel="noopener noreferrer">Higuchi Ai</a></h2>
     <h3 align="center">Song: コインロッカーにて</h3>
     <hr>
     <details>
@@ -63,15 +63,15 @@
     </p>
     <h3 align="center">Listen to the Song</h3>
     <p align="center">
-        <a href="https://www.youtube.com/watch?v=jCVMRVuIsds">YouTube</a> | 
-        <a href="https://open.spotify.com/track/3HDEDWtVoozk7I2yvdoy9m?si=d9cc7b61ad93457f">Spotify</a> | 
-        <a href="https://music.apple.com/jp/song/%E3%82%B3%E3%82%A4%E3%83%B3%E3%83%AD%E3%83%83%E3%82%AB%E3%83%BC%E3%81%AB%E3%81%A6/1390414658">Apple Music</a> 
+        <a href="https://www.youtube.com/watch?v=jCVMRVuIsds" target="_blank" rel="noopener noreferrer">YouTube</a> | 
+        <a href="https://open.spotify.com/track/3HDEDWtVoozk7I2yvdoy9m?si=d9cc7b61ad93457f" target="_blank" rel="noopener noreferrer">Spotify</a> | 
+        <a href="https://music.apple.com/jp/song/%E3%82%B3%E3%82%A4%E3%83%B3%E3%83%AD%E3%83%83%E3%82%AB%E3%83%BC%E3%81%AB%E3%81%A6/1390414658" target="_blank" rel="noopener noreferrer">Apple Music</a> 
     </p>
     <h3 align="center">Follow QWER</h3>
     <p align="center">
-        <a href="https://x.com/HiguchiAi">X</a> | 
-        <a href="https://www.instagram.com/higuchiai.1128/">Instagram</a> | 
-        <a href="https://www.youtube.com/@AiHiguchiOfficial">YouTube</a>
+        <a href="https://x.com/HiguchiAi" target="_blank" rel="noopener noreferrer">X</a> | 
+        <a href="https://www.instagram.com/higuchiai.1128/" target="_blank" rel="noopener noreferrer">Instagram</a> | 
+        <a href="https://www.youtube.com/@AiHiguchiOfficial" target="_blank" rel="noopener noreferrer">YouTube</a>
     </p>
     </details>
 </td>

--- a/refresh-featured-artist.js
+++ b/refresh-featured-artist.js
@@ -26,7 +26,7 @@ const refreshFeaturedArtist = async () => {
     <p align="center">
         <img src="${artist_image_url}" alt="${artist_name} Image" width="200"/>
     </p>
-    <h2 align="center">Artist: <a href="${artist_link}">${artist_name}</a></h2>
+    <h2 align="center">Artist: <a href="${artist_link}" target="_blank" rel="noopener noreferrer">${artist_name}</a></h2>
     <h3 align="center">Song: ${song_title}</h3>
     <hr>
     <details>
@@ -38,15 +38,15 @@ const refreshFeaturedArtist = async () => {
     </p>
     <h3 align="center">Listen to the Song</h3>
     <p align="center">
-        <a href="${song_youtube_url}">YouTube</a> | 
-        <a href="${song_spotify_url}">Spotify</a> | 
-        <a href="${song_apple_url}">Apple Music</a> 
+        <a href="${song_youtube_url}" target="_blank" rel="noopener noreferrer">YouTube</a> | 
+        <a href="${song_spotify_url}" target="_blank" rel="noopener noreferrer">Spotify</a> | 
+        <a href="${song_apple_url}" target="_blank" rel="noopener noreferrer">Apple Music</a> 
     </p>
     <h3 align="center">Follow QWER</h3>
     <p align="center">
-        <a href="${x_url}">X</a> | 
-        <a href="${instagram_url}">Instagram</a> | 
-        <a href="${youtube_url}">YouTube</a>
+        <a href="${x_url}" target="_blank" rel="noopener noreferrer">X</a> | 
+        <a href="${instagram_url}" target="_blank" rel="noopener noreferrer">Instagram</a> | 
+        <a href="${youtube_url}" target="_blank" rel="noopener noreferrer">YouTube</a>
     </p>
     </details>
 </td>`;


### PR DESCRIPTION
Add target="_blank" rel="noopener noreferrer"
attributes to all external links to open them
in a new tab by default, while ensuring web
security.

This affects both the 'feature artists' section,
and the 'language & tools' section.

Same addition made to the template in the
refresh-featured-artist.js updater script.

---
name: Pull Request
about: open links in new tab by default
title: 'Feature: open links in new tab by default'
labels: enhancement
assignees: @kevinweejh 

---

**Related Issue(s)**
#11 

**Problem / Motivation**
Links to external sites should open in new tab by default, so as to minimise disruption to user journey.

**Solution**
Add attributes `target="_blank" rel="noopener noreferrer"` to all links to external sites.

**Testing Done**
N.A.

**Screenshots**
N.A.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Additional Notes**
NIL
