### PR TITLE
fix: provide working links for profile photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
   <tr>
     <td>
     <p align="center">
-        <img src="https://www.google.com/url?sa=i&url=https%3A%2F%2Fmusic.apple.com%2Fus%2Fartist%2Fstmlt%2F1654707363&psig=AOvVaw0KNohYRfLQrXxNgdtM-wYM&ust=1717341164860000&source=images&cd=vfe&opi=89978449&ved=0CBIQjRxqFwoTCKCIw8PYuoYDFQAAAAAdAAAAABAE" alt="ステミレイツ Image" width="200"/>
+        <img src="https://yt3.googleusercontent.com/VfcJwelfOBmCXV4LNlMmgZKjVzP3jxIBPjYaOnfQK2kWnoU50SqbT9K9S9SteDXkVNmeQOj-PA=s900-c-k-c0x00ffffff-no-rj" alt="ステミレイツ Image" width="200"/>
     </p>
     <h2 align="center">Artist: <a href="https://www.youtube.com/channel/UCVVHUuwTkomWfjE9hJicoGQ" target="_blank" rel="noopener noreferrer">ステミレイツ</a></h2>
     <h3 align="center">Song: 追求</h3>

--- a/assets/data.json
+++ b/assets/data.json
@@ -494,7 +494,7 @@
         "youtube_url": "https://www.youtube.com/@RedHotChiliPeppers"
     },
     {
-        "artist_image_url": "https://www.google.com/url?sa=i&url=https%3A%2F%2Fopen.spotify.com%2Fartist%2F38WbKH6oKAZskBhqDFA8Uj&psig=AOvVaw03jCU1FFENUnJpexBfn7Nn&ust=1717340344357000&source=images&cd=vfe&opi=89978449&ved=0CBIQjRxqFwoTCLCvhrvVuoYDFQAAAAAdAAAAABBV",
+        "artist_image_url": "https://cdns-images.dzcdn.net/images/artist/61bcbf8296b1669499064406c534d39d/500x500.jpg",
         "artist_name": "ずっと真夜中でいいのに。",
         "artist_link": "https://zutomayo.net/",
         "artist_about": "ずっと真夜中でいいのに。(ZUTOMAYO) is a secretive band that conceals their identities. However, it's quite impossible to conceal the overflowing talent this group oozes with. Their songs are characterised by punchy basslines, punctuated with game noises, and vocals take make you feel like they're running around you in circles really quickly.",
@@ -507,7 +507,7 @@
         "youtube_url": "https://www.youtube.com/@ZUTOMAYO"
     },
     {
-        "artist_image_url": "https://www.google.com/url?sa=i&url=https%3A%2F%2Fopen.spotify.com%2Fartist%2F38WbKH6oKAZskBhqDFA8Uj&psig=AOvVaw03jCU1FFENUnJpexBfn7Nn&ust=1717340344357000&source=images&cd=vfe&opi=89978449&ved=0CBIQjRxqFwoTCLCvhrvVuoYDFQAAAAAdAAAAABBV",
+        "artist_image_url": "https://cdns-images.dzcdn.net/images/artist/61bcbf8296b1669499064406c534d39d/500x500.jpg",
         "artist_name": "ずっと真夜中でいいのに。",
         "artist_link": "https://zutomayo.net/",
         "artist_about": "ずっと真夜中でいいのに。(ZUTOMAYO) is a secretive band that conceals their identities. However, it's quite impossible to conceal the overflowing talent this group oozes with. Their songs are characterised by punchy basslines, punctuated with game noises, and vocals take make you feel like they're running around you in circles really quickly.",
@@ -520,7 +520,7 @@
         "youtube_url": "https://www.youtube.com/@ZUTOMAYO"
     },
     {
-        "artist_image_url": "https://www.google.com/url?sa=i&url=https%3A%2F%2Fmusic.apple.com%2Fus%2Fartist%2Fstmlt%2F1654707363&psig=AOvVaw0KNohYRfLQrXxNgdtM-wYM&ust=1717341164860000&source=images&cd=vfe&opi=89978449&ved=0CBIQjRxqFwoTCKCIw8PYuoYDFQAAAAAdAAAAABAE",
+        "artist_image_url": "https://yt3.googleusercontent.com/VfcJwelfOBmCXV4LNlMmgZKjVzP3jxIBPjYaOnfQK2kWnoU50SqbT9K9S9SteDXkVNmeQOj-PA=s900-c-k-c0x00ffffff-no-rj",
         "artist_name": "ステミレイツ",
         "artist_link": "https://www.youtube.com/channel/UCVVHUuwTkomWfjE9hJicoGQ",
         "artist_about": "Saxophone player in a rock band? Sign me up!",
@@ -533,7 +533,7 @@
         "youtube_url": "https://www.youtube.com/channel/UCVVHUuwTkomWfjE9hJicoGQ"
     },
     {
-        "artist_image_url": "https://www.google.com/url?sa=i&url=https%3A%2F%2Fmusic.apple.com%2Fus%2Fartist%2Fstmlt%2F1654707363&psig=AOvVaw0KNohYRfLQrXxNgdtM-wYM&ust=1717341164860000&source=images&cd=vfe&opi=89978449&ved=0CBIQjRxqFwoTCKCIw8PYuoYDFQAAAAAdAAAAABAE",
+        "artist_image_url": "https://yt3.googleusercontent.com/VfcJwelfOBmCXV4LNlMmgZKjVzP3jxIBPjYaOnfQK2kWnoU50SqbT9K9S9SteDXkVNmeQOj-PA=s900-c-k-c0x00ffffff-no-rj",
         "artist_name": "ステミレイツ",
         "artist_link": "https://www.youtube.com/channel/UCVVHUuwTkomWfjE9hJicoGQ",
         "artist_about": "Saxophone player in a rock band? Sign me up!",
@@ -559,7 +559,7 @@
         "youtube_url": "https://www.youtube.com/channel/UCh0H_Bie0cJ5zpat63aJ1dQ"
     },
     {
-        "artist_image_url": "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.billboard.com%2Fpro%2Fhow-vulfpeck-sold-out-madison-square-garden-without-manager-label%2F&psig=AOvVaw1JIfZF0lA64q03-QwNBuZI&ust=1717341787807000&source=images&cd=vfe&opi=89978449&ved=0CBIQjRxqFwoTCND49v_auoYDFQAAAAAdAAAAABAE",
+        "artist_image_url": "https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fd1e00ek4ebabms.cloudfront.net%2Fproduction%2Fa685cfb0-24a5-4719-a41a-1071133ec81d.jpg?source=next-article&fit=scale-down&quality=highest&width=700&dpr=1",
         "artist_name": "Vulfpeck",
         "artist_link": "https://www.vulfpeck.com/",
         "artist_about": "Release a silent album to fund an admission-free tour? Sell out MSG without a manager or label? Rotating roster of some of the most talented musicians? No rehearsals before the show, yet still delivering? What more can you ask for?",
@@ -572,7 +572,7 @@
         "youtube_url": "https://www.youtube.com/@Vulf"
     },
     {
-        "artist_image_url": "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.billboard.com%2Fpro%2Fhow-vulfpeck-sold-out-madison-square-garden-without-manager-label%2F&psig=AOvVaw1JIfZF0lA64q03-QwNBuZI&ust=1717341787807000&source=images&cd=vfe&opi=89978449&ved=0CBIQjRxqFwoTCND49v_auoYDFQAAAAAdAAAAABAE",
+        "artist_image_url": "https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fd1e00ek4ebabms.cloudfront.net%2Fproduction%2Fa685cfb0-24a5-4719-a41a-1071133ec81d.jpg?source=next-article&fit=scale-down&quality=highest&width=700&dpr=1",
         "artist_name": "Vulfpeck",
         "artist_link": "https://www.vulfpeck.com/",
         "artist_about": "Release a silent album to fund an admission-free tour? Sell out MSG without a manager or label? Rotating roster of some of the most talented musicians? No rehearsals before the show, yet still delivering? What more can you ask for?",


### PR DESCRIPTION
Fix broken link in README for ステミレイツ.

Preemptively fix broken links in data.json for
ステミレイツ, Vulfpeck, and Zutomayo

---
name: Pull Request
about: Fix broken links
title: 'Feature: Fix broken links'
labels: enhancement
assignees: @kevinweejh 

---

**Related Issue(s)**
#13 

**Problem / Motivation**
Broken links for profile photos led to redirect notices, meant that some profile photos wouldn't load.

**Solution**
Replace broken links with working ones that point to the image source directly. 

**Testing Done**
Manual testing of the current, and new links. 

**Screenshots**
N.A.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Additional Notes**
NIL
