### PR TITLE
fix: add template literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,29 +49,29 @@
   <tr>
     <td>
     <p align="center">
-        <img src="https://cdns-images.dzcdn.net/images/artist/61bcbf8296b1669499064406c534d39d/500x500.jpg" alt="ずっと真夜中でいいのに。 Image" width="200"/>
+        <img src="https://i.scdn.co/image/ab6761610000517483e2d0c9611f1fb6baafcb36" alt="YOASOBI Image" width="200"/>
     </p>
-    <h2 align="center">Artist: <a href="https://zutomayo.net/" target="_blank" rel="noopener noreferrer">ずっと真夜中でいいのに。</a></h2>
-    <h3 align="center">Song: 綺羅キラー</h3>
+    <h2 align="center">Artist: <a href="https://www.yoasobi-music.jp/" target="_blank" rel="noopener noreferrer">YOASOBI</a></h2>
+    <h3 align="center">Song: 群青</h3>
     <hr>
     <details>
     <summary align="center">Tell Me More</summary>
     <br>
     <h3 align="center">Why I Love This Artist</h3>
     <p align="center">
-    ずっと真夜中でいいのに。(ZUTOMAYO) is a secretive band that conceals their identities. However, it's quite impossible to conceal the overflowing talent this group oozes with. Their songs are characterised by punchy basslines, punctuated with game noises, and vocals take make you feel like they're running around you in circles really quickly.
+    YOASOBI is a Japanese pop duo that, in my opinion, has only released bangers since their formation in 2019. Their sound is unmistakable, extremely catchy, and simply infectious. Sincerely, I long for the day I get to see them live, to soak in the magic of the YOASOBI experience.
     </p>
     <h3 align="center">Listen to the Song</h3>
     <p align="center">
-        <a href="https://www.youtube.com/watch?v=e5LaKxJVeVI" target="_blank" rel="noopener noreferrer">YouTube</a> | 
-        <a href="https://open.spotify.com/track/5nnIVX0gjyABWN0JYlNOUE?si=d61f098500474993" target="_blank" rel="noopener noreferrer">Spotify</a> | 
-        <a href="https://music.apple.com/jp/album/%E7%B6%BA%E7%BE%85%E3%82%AD%E3%83%A9%E3%83%BC-feat-mori-calliope/1688968525?i=1688968536" target="_blank" rel="noopener noreferrer">Apple Music</a> 
+        <a href="https://www.youtube.com/watch?v=ng08QQvjV0U" target="_blank" rel="noopener noreferrer">YouTube</a> | 
+        <a href="https://open.spotify.com/track/1zd35Y44Blc1CwwVbW3Qnk?si=fc2e73d4e5824cec" target="_blank" rel="noopener noreferrer">Spotify</a> | 
+        <a href="https://music.apple.com/jp/album/%E7%BE%A4%E9%9D%92/1528119626?i=1528119630" target="_blank" rel="noopener noreferrer">Apple Music</a> 
     </p>
-    <h3 align="center">Follow QWER</h3>
+    <h3 align="center">Follow YOASOBI</h3>
     <p align="center">
-        <a href="https://x.com/zutomayo" target="_blank" rel="noopener noreferrer">X</a> | 
-        <a href="https://www.instagram.com/zutomayo/" target="_blank" rel="noopener noreferrer">Instagram</a> | 
-        <a href="https://www.youtube.com/@ZUTOMAYO" target="_blank" rel="noopener noreferrer">YouTube</a>
+        <a href="https://twitter.com/YOASOBI_staff" target="_blank" rel="noopener noreferrer">X</a> | 
+        <a href="https://www.instagram.com/yoasobi_staff_/" target="_blank" rel="noopener noreferrer">Instagram</a> | 
+        <a href="https://www.youtube.com/@Ayase_YOASOBI" target="_blank" rel="noopener noreferrer">YouTube</a>
     </p>
     </details>
 </td>

--- a/refresh-featured-artist.ts
+++ b/refresh-featured-artist.ts
@@ -63,7 +63,7 @@ const refreshFeaturedArtist = async (): Promise<void> => {
         <a href="${song_spotify_url}" target="_blank" rel="noopener noreferrer">Spotify</a> | 
         <a href="${song_apple_url}" target="_blank" rel="noopener noreferrer">Apple Music</a> 
     </p>
-    <h3 align="center">Follow QWER</h3>
+    <h3 align="center">Follow ${artist_name}</h3>
     <p align="center">
         <a href="${x_url}" target="_blank" rel="noopener noreferrer">X</a> | 
         <a href="${instagram_url}" target="_blank" rel="noopener noreferrer">Instagram</a> | 


### PR DESCRIPTION
Add template literal to dynamically insert
the artist's name using the artist_name variable.

---
name: Pull Request
about: Add template literal
title: 'Feature: Add template literal'
labels: enhancement
assignees: @kevinweejh 

---

**Related Issue(s)**
#18 

**Problem / Motivation**
The Socials portion of the 'Featured Artists' section did not update its heading when the `refresh-featured-artist.ts` script was run. As such, it incorrectly reflected 'Follow QWER' even at times when QWER was not the featured artist. This is confusing and incorrect.

**Solution**
Add template literal to dynamically insert the current featured artist's name in the heading of the Socials portion. 

**Testing Done**
Manual testing in the `issue-18-fix` feature branch. 

**Screenshots**
![image](https://github.com/kevinweejh/kevinweejh/assets/34761000/e217657a-ca67-4ec0-8ac6-32d9431d3963)


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Additional Notes**
N.A.
